### PR TITLE
Visible upgrades in tech tree

### DIFF
--- a/GameData/ProceduralFairings/common.cfg
+++ b/GameData/ProceduralFairings/common.cfg
@@ -31,3 +31,87 @@ PROCROCKET_MAXDIAMETER
   experimentalRocketry = 10
   sandbox = 50
 }
+
+//-----------------------------------------------------------------------
+// Dummy parts to represent Procedural Fairings upgrades in the tech tree
+
+PART {
+    name = pf_tech_fairing05m
+    TechRequired = precisionEngineering
+    title = Procedural Fairings Uprade
+    description = Allows fairings and fuselages to be made as small as 0.5 m.
+}
+
+PART {
+    name = pf_tech_fairing3m
+    TechRequired = aerodynamicSystems
+    title = Procedural Fairings Uprade
+    description = Allows fairings to be expanded to 3 m.
+}
+
+PART {
+    name = pf_tech_fairing6m
+    TechRequired = heavyAerodynamics
+    title = Procedural Fairings Uprade
+    description = Allows fairings to be expanded to 6 m.
+}
+
+PART {
+    name = pf_tech_fairing10m
+    TechRequired = experimentalAerodynamics
+    title = Procedural Fairings Uprade
+    description = Allows fairings to be expanded to 10 m.
+}
+
+PART {
+    name = pf_tech_fuselage3m
+    // Redundant with tech that introduces fuselages
+    // TechRequired = advConstruction
+    title = Procedural Fairings Uprade
+    description = Allows fuselages to be expanded to 3 m.
+}
+
+PART {
+    name = pf_tech_fuselage6m
+    TechRequired = veryHeavyRocketry
+    title = Procedural Fairings Uprade
+    description = Allows fuselages to be expanded to 6 m.
+}
+
+PART {
+    name = pf_tech_fuselage10m
+    TechRequired = experimentalRocketry
+    title = Procedural Fairings Uprade
+    description = Allows fuselages to be expanded to 10 m.
+}
+
+@PART[pf_tech*]
+{
+    %module = Part
+    %author = Starstrider42 (config), e-dog (model)
+    %MODEL
+    {
+      %model = ProceduralFairings/sideModel
+    }
+
+    // Since unlocking these parts is not strictly necessary to get the upgrade, 
+    //	costs should be set to zero. Otherwise, the illusion will be broken by KSP 0.24
+    %entryCost = 0
+    %cost = 0
+    %category = none
+    %manufacturer = Keramzit Engineering
+
+    %mass = 0.1
+    %maximum_drag = 0.1
+    %minimum_drag = 0.1
+    %crashTolerance = 8
+    %maxTemp = 3600
+}
+
+@PART[pf_tech_fuselage*]
+{
+    @MODEL
+    {
+      %texture = fairing1, ProceduralFairings/fuselage1
+    }
+}


### PR DESCRIPTION
This is a port of MechJeb's system for visualizing tech upgrades to Procedural Fairings. This should alleviate some of the confusion about which technologies improve fairings.

Dummy parts will help users see where fairing upgrades appear in tech tree (see screenshot). Invalid values of `category` ensure that these parts will appear only in the tech tree, and never in the VAB. ![An example of a dummy part in the tech tree](https://cloud.githubusercontent.com/assets/6760782/3282481/e1ed5dde-f4f1-11e3-8222-7fa8760e5100.png)

One possible pitfall is KSP 0.24 compatibility. If 0.24 requires you to unlock parts separately after researching a technology, players may quickly realize that they do not actually need to unlock a dummy part to get the corresponding benefits.
